### PR TITLE
Proxy authentication and proxy type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,7 @@
 	"autoload": {
 		"psr-4": {
 			"SerpScraper\\": "src/"
-		},
-		"files": [
-			"src/dbc/deathbycaptcha.php"
-		]
+		}
 	},
 	"require-dev": {
 		"phpunit/phpunit": "8"


### PR DESCRIPTION
It will be great if there is automated proxy authentication and proxy type checking since based on my experience curl will needed proxy type declared if the proxy are socks, either socks 4, 4a, or even 5

I had successfully creating automated proxy authentication checking on the file gscraper.php that I had sent to you before and still struggling how to get proxy type automatically and maybe you can create it since you're familiar with proxy :)